### PR TITLE
feat(api/ideorama): add the rout to get the empty ideorama

### DIFF
--- a/apps/api/src/modules/ideorama/ideorama.controller.ts
+++ b/apps/api/src/modules/ideorama/ideorama.controller.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-import { Response } from 'express';
+import { Request, Response } from 'express';
 
 import { AuthenticatedRequest } from '../../types';
 import {
@@ -183,7 +183,7 @@ const saveIdeoramaController = async (
       await updateIdeoramaModelPath(newIdeorama.id, uploadPath)
 
       // Save in uploads dir
-      const emptyScene = fs.readFileSync('uploads/scene-empty.json')
+      const emptyScene = fs.readFileSync('uploads/scene-000.json')
       fs.writeFileSync(uploadPath, emptyScene)
 
       return res.status(200).json({
@@ -254,5 +254,17 @@ const deleteIdeoramaController = async (
   }
 };
 
-export { deleteIdeoramaController, getIdeoramaByIdController, getUserIdeoramasController, saveIdeoramaController };
+const getEmptyIdeorama = async(
+  req: Request,
+  res: Response
+) => {
+  return res.status(200).json({
+    status: 'success',
+    data: {model: JSON.parse(fs.readFileSync(getUploadPath("empty"), "utf-8"))},
+    status_code: 200,
+  });
+}
+
+
+export { deleteIdeoramaController, getEmptyIdeorama, getIdeoramaByIdController, getUserIdeoramasController, saveIdeoramaController };
 

--- a/apps/api/src/modules/ideorama/ideorama.route.ts
+++ b/apps/api/src/modules/ideorama/ideorama.route.ts
@@ -4,6 +4,7 @@ import authenticate from '../../middlewares/authenticate';
 
 import {
   deleteIdeoramaController,
+  getEmptyIdeorama,
   getIdeoramaByIdController,
   getUserIdeoramasController,
   saveIdeoramaController
@@ -15,5 +16,6 @@ ideoramasRoutes.post('/', authenticate, getIdeoramaByIdController);
 ideoramasRoutes.post('/save', authenticate, saveIdeoramaController);
 ideoramasRoutes.post('/all', authenticate, getUserIdeoramasController);
 ideoramasRoutes.post('/delete', authenticate, deleteIdeoramaController);
+ideoramasRoutes.get('/empty', getEmptyIdeorama);
 
 export default ideoramasRoutes;


### PR DESCRIPTION
# Pull Request

## Description

Ideorama reset frontend

## Related Issue

https://github.com/digifactori-idearium/digifactori-idearium/issues/63

Fixes #(issue)

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation updates
- [ ] style: Code style/formatting changes
- [ ] refactor: Code refactoring
- [ ] perf: Performance improvements
- [ ] test: Test additions/updates
- [ ] chore: Build process or tooling changes
- [ ] ci: CI configuration changes
- [ ] other: <!-- describe -->

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Test Evidence

<!-- Please upload a screenshot showing all tests passing -->
<!-- This is required for all PRs that include code changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes if UI is affected -->

## Documentation Screenshots (if applicable)

<!-- If you've made code changes, please add screenshots of the updated documentation -->
<!-- This is required for all PRs that include code changes that affect user-facing features -->

## Checklist

<!-- Mark the appropriate option with an "x" -->

- [ ] My code follows the project's coding style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have included a screenshot showing all tests passing
- [ ] I have included documentation screenshots (if applicable)

## Additional Notes

<!-- Add any other information about the PR here -->
